### PR TITLE
bump to latest deps

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router} from 'react-router';
-import BrowserHistory from 'react-router/lib/BrowserHistory';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
 import Routes from './routes';
 import ReactRouterRelay from 'react-router-relay';
 
 ReactDOM.render(
   <Router
-    history={new BrowserHistory()}
+    history={createBrowserHistory()}
     createElement={ReactRouterRelay.createElement}
   >
     {Routes}

--- a/js/components/ChatApp.js
+++ b/js/components/ChatApp.js
@@ -12,13 +12,14 @@
 
 import React from 'react';
 import Relay from 'react-relay';
+import { PropTypes } from 'react-router';
 import ThreadSection from './ThreadSection';
 import MessageSection from './MessageSection';
 
 class ChatApp extends React.Component {
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired,
+    history: PropTypes.history,
   }
 
   componentWillMount() {
@@ -28,7 +29,7 @@ class ChatApp extends React.Component {
     // TODO: better if we can do it in route config
     const currentThreadID = this.props.viewer.threads.edges[0].node.id;
     if (window.location.pathname === '/' ) {
-      this.context.router.transitionTo(`/thread/${currentThreadID}`);
+      this.context.history.pushState(null, `/thread/${currentThreadID}`);
     }
   }
 

--- a/js/components/MessageSection.js
+++ b/js/components/MessageSection.js
@@ -11,7 +11,6 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import Relay from 'react-relay';
 import MessageComposer from './MessageComposer';
 import MessageListItem from './MessageListItem';
@@ -44,7 +43,7 @@ class MessageSection extends React.Component {
   }
 
   _scrollToBottom() {
-    var ul = ReactDOM.findDOMNode(this.refs.messageList);
+    var ul = this.refs.messageList;
     ul.scrollTop = ul.scrollHeight;
   }
 

--- a/js/components/ThreadListItem.js
+++ b/js/components/ThreadListItem.js
@@ -12,13 +12,14 @@
 
 import React from 'react';
 import Relay from 'react-relay';
+import { PropTypes } from 'react-router';
 import classNames from 'classnames';
 import MarkThreadAsReadMutation from '../mutations/MarkThreadAsReadMutation';
 
 class ThreadListItem extends React.Component {
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired,
+    history: PropTypes.history,
   }
 
   render() {
@@ -43,7 +44,7 @@ class ThreadListItem extends React.Component {
   }
 
   _onClick = () => {
-    this.context.router.transitionTo(`/thread/${this.props.thread.id}`);
+    this.context.history.pushState(null, `/thread/${this.props.thread.id}`);
     // viewer, thread, isRead here would be props in MarkThreadAsReadMutation
     // 這裡的 viewer, thread, isRead 會變成 MarkThreadAsReadMutation
     // 的 props

--- a/package.json
+++ b/package.json
@@ -22,27 +22,28 @@
     "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "devDependencies": {
-    "babel-eslint": "^4.0.5",
-    "eslint": "^1.0.0",
-    "eslint-loader": "^1.0.0",
-    "eslint-plugin-react": "^3.2.0",
-    "react-hot-loader": "^1.2.8"
+    "babel-eslint": "4.1.2",
+    "eslint": "1.4.1",
+    "eslint-loader": "1.0.0",
+    "eslint-plugin-react": "3.3.2",
+    "react-hot-loader": "1.3.0"
   },
   "dependencies": {
-    "babel": "5.8.21",
+    "babel": "5.8.23",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "0.1.1",
-    "classnames": "^2.1.3",
-    "express": "^4.13.1",
-    "express-graphql": "^0.3.0",
-    "graphql": "^0.4.2",
-    "graphql-relay": "^0.3.0",
-    "react": "^0.14.0-beta3",
-    "react-dom": "^0.14.0-beta3",
-    "react-relay": "^0.1.1",
-    "react-router": "1.0.0-beta3",
-    "react-router-relay": "^0.4.2",
-    "webpack": "^1.10.5",
-    "webpack-dev-server": "^1.10.1"
+    "babel-relay-plugin": "0.2.3",
+    "classnames": "2.1.3",
+    "express": "4.13.3",
+    "express-graphql": "0.3.0",
+    "graphql": "0.4.4",
+    "graphql-relay": "0.3.2",
+    "history": "1.9.1",
+    "react": "0.14.0-rc1",
+    "react-dom": "0.14.0-rc1",
+    "react-relay": "0.3.1",
+    "react-router": "1.0.0-rc1",
+    "react-router-relay": "0.5.0",
+    "webpack": "1.12.1",
+    "webpack-dev-server": "1.11.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,15 @@
 var path = require('path');
 var webpack = require('webpack');
 
+var resolveFromHere = path.resolve.bind(path, __dirname);
+var resolveModuleDir = resolveFromHere.bind(path, 'node_modules');
+
 module.exports = {
   devtool: '#source-map',
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',
-    path.resolve(__dirname, 'js', 'app.js'),
+    resolveFromHere('js', 'app.js'),
   ],
   output: {
     path: '/',
@@ -17,6 +20,11 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
+  resolve: {
+    alias: {
+      'react': resolveModuleDir('react')
+    }
+  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
i must admit i did this quickly to make it work (initially didn't work because [batchedUpdates wasn't defined](https://github.com/facebook/relay/commit/2d82240)) unfortunately updating all deps resulted in the duplicate react problem.. so i applied a [quick fix](https://github.com/jnuine/relay-chat/commit/a92189062c479072928d1995c63143b7a5c34846) i usually use.

updates i had to make:
- react-router: `history` is now in its own module. `transitionTo()` is gone, use `history.pushState(null, )`
- react: refs: no need for `findDOMNode()` anymore.

i also used fixed deps rather than `^` don't know if you prefer these or not. but one of the reasons i stumbled upon the initial problem is probably because the version installed by npm was different to the one you had this project working with. 
